### PR TITLE
fix: emit diagnostics for ~D unmatched parent/child codes

### DIFF
--- a/docs/ai-workflow/current-handover.md
+++ b/docs/ai-workflow/current-handover.md
@@ -6,6 +6,14 @@
 
 ## Recent Changes
 
+### 2026-05-06 — Fix: ~D records emit diagnostics for unmatched codes (#96)
+
+- **Added warn-level diagnostics** in `BC3Builder.assembleHierarchy()` when ~D parent or child code does not match any ~C concept
+- Previously these were silently skipped — now emit `BC3_D_MISSING_PARENT_CODE` and `BC3_D_MISSING_CHILD_CODE`
+- **Added 3 regression tests** in `tests/api/DSilentDiagnostics.test.ts`
+- **Branch:** `fix/96-d-silent-diagnostics`
+- Fixes #96
+
 ### 2026-05-06 — Feature: parse ~O records (#94)
 
 - **Created `CostOverride` domain class** with `conceptCode` + `locations[]` (`CostLocation: { location, price }`)
@@ -88,17 +96,17 @@ Reorganized all `docs/` content into a clear, navigable directory layout. Fixed 
 
 ## Notes
 
-- All 99 tests pass; `npm run ci` passes.
+- All 102 tests pass; `npm run ci` passes.
 - Old root-level doc stubs have been deleted. All broken references across the repo have been fixed.
 - The DParser heuristic for detecting child codes requires 4+ digit numeric codes or alphanumeric codes. Short numeric codes (1-3 digits) without letters are still treated as percentage codes — this is a pre-existing limitation, not introduced by this fix.
 
 ## Next Steps
 
-1. **Fix ~D silent diagnostics** — ~D records silently skip children with unmatched codes. See work-to-issue-mapping.md Priority 1 #3.
-2. **Fix KParser negative digit counts** — VQUISI has `-9` as first digit count. See work-to-issue-mapping.md Priority 1 #4.
-3. **ISO-8859-1 encoding support** — all corpus files are Latin-1.
-4. **Regression tests for untested parsers** — 10 of 13 parsers have no dedicated tests.
-5. **Null byte stripping preprocessor** — unblocks Excesos-Mod.
+1. **Fix KParser negative digit counts** — VQUISI has `-9` as first digit count. See work-to-issue-mapping.md Priority 1 #4.
+2. **ISO-8859-1 encoding support** — all corpus files are Latin-1.
+3. **Regression tests for untested parsers** — 10 of 13 parsers have no dedicated tests.
+4. **Null byte stripping preprocessor** — unblocks Excesos-Mod.
+5. **Backslash context-sensitivity in ~V** — `FIEBDC-3/2020\02102025` uses `\` as date separator.
 
 ---
 

--- a/src/builder/BC3Builder.ts
+++ b/src/builder/BC3Builder.ts
@@ -209,9 +209,15 @@ export class BC3Builder {
       const parentNode = nodes.get(normalizedParent);
 
       if (!parentNode) {
-        // Parent concept not found - will be reported as diagnostic later
-        // This can happen if the parent code in the decomposition doesn't match
-        // the normalized code used when creating the concept node
+        // Parent concept not found for this decomposition
+        if (this.diagnostics) {
+          this.diagnostics.push({
+            level: 'warn',
+            code: 'BC3_D_MISSING_PARENT_CODE',
+            message: `~D parent code "${parentCode}" does not match any ~C concept`,
+            recordType: 'D',
+          });
+        }
         continue;
       }
 
@@ -220,7 +226,15 @@ export class BC3Builder {
         const childNode = nodes.get(normalizedChild);
 
         if (!childNode) {
-          // Child concept not found - will be reported as diagnostic later
+          // Child concept not found for this decomposition line
+          if (this.diagnostics) {
+            this.diagnostics.push({
+              level: 'warn',
+              code: 'BC3_D_MISSING_CHILD_CODE',
+              message: `~D child code "${line.code}" under parent "${normalizedParent}" does not match any ~C concept`,
+              recordType: 'D',
+            });
+          }
           continue;
         }
 

--- a/tests/api/DSilentDiagnostics.test.ts
+++ b/tests/api/DSilentDiagnostics.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { BC3 } from '../../src/api/BC3.js';
+
+const UNMATCHED_PARENT_BC3 = [
+  '~V|T|FIEBDC-3/2020|||',
+  '~C|CHILD01||Child|||1|',
+  '~D|MISSING_PARENT|CHILD01\\1\\1\\|',
+].join('\r\n');
+
+const UNMATCHED_CHILD_BC3 = [
+  '~V|T|FIEBDC-3/2020|||',
+  '~C|PARENT||Parent|||0|',
+  '~D|PARENT|MISSING_CHILD\\1\\1\\|',
+].join('\r\n');
+
+describe('~D silent diagnostics', () => {
+  it('emits warning when ~D parent code unmatched', () => {
+    const result = BC3.parse(UNMATCHED_PARENT_BC3, { mode: 'lenient' });
+    assert.ok(result.document);
+
+    const warnings = result.diagnostics.filter(
+      (d) => d.code === 'BC3_D_MISSING_PARENT_CODE',
+    );
+    assert.equal(warnings.length, 1);
+    assert.equal(warnings[0]!.level, 'warn');
+    assert.match(warnings[0]!.message, /MISSING_PARENT/);
+  });
+
+  it('emits warning when ~D child code unmatched', () => {
+    const result = BC3.parse(UNMATCHED_CHILD_BC3, { mode: 'lenient' });
+    assert.ok(result.document);
+
+    const warnings = result.diagnostics.filter(
+      (d) => d.code === 'BC3_D_MISSING_CHILD_CODE',
+    );
+    assert.equal(warnings.length, 1);
+    assert.equal(warnings[0]!.level, 'warn');
+    assert.match(warnings[0]!.message, /MISSING_CHILD/);
+  });
+
+  it('does not emit warnings when all codes match', () => {
+    const fixture = [
+      '~V|T|FIEBDC-3/2020|||',
+      '~C|PARENT||Parent|||0|',
+      '~C|1001||Child|||1|',
+      '~D|PARENT|1001\\1\\1\\|',
+    ].join('\r\n');
+
+    const result = BC3.parse(fixture, { mode: 'lenient' });
+    assert.ok(result.document);
+    assert.equal(result.diagnostics.length, 0);
+  });
+});


### PR DESCRIPTION
~D records silently skipped children when parent or child codes did not match any ~C concept. No diagnostic was emitted, masking hierarchy gaps.

Now emits warn-level diagnostics:
- BC3_D_MISSING_PARENT_CODE — parent code not found
- BC3_D_MISSING_CHILD_CODE — child code not found

Fixes #96

## Type of change
- [ ] Feature
- [x] Bug fix
- [ ] Docs
- [ ] Chore / CI
- [ ] Refactor

## Changesets
- [x] This PR requires a release (public API / behavior change) → `npm run changeset` added
- [ ] This PR does NOT require a release (docs/ci/internal tooling only)

> If a Changeset is required, ensure a file exists in `.changeset/`.

## Checklist
- [x] `npm run ci` passes locally
- [x] Code is formatted (Prettier)
- [x] No unnecessary files committed (e.g. `dist/`, `node_modules/`)
- [x] Public API changes are documented (README / docs)
- [x] Backward compatibility considered (if applicable)

## Notes for reviewers
- Anything to pay attention to?
