### PR TITLE
Feat/100 latin1 encoding support

### DIFF
--- a/docs/ai-workflow/current-handover.md
+++ b/docs/ai-workflow/current-handover.md
@@ -6,6 +6,12 @@
 
 ## Recent Changes
 
+### 2026-05-06 — Docs: ISO-8859-1 encoding contract (#100)
+
+- **Documented** in `public-api.md` that ISO-8859-1 decoding is the caller's responsibility (not the library's). All corpus files use Latin-1 — callers must decode before passing to `BC3.parse()` (as demonstrated in `scripts/tokenize.mjs`)
+- **Branch:** `feat/100-latin1-encoding-support`
+- Fixes #100
+
 ### 2026-05-06 — Fix: verify KParser handles negative digit counts (#98)
 
 - **Added test** for `-9` digit count (VQUISI corpus pattern). KParser stores subfields as strings — no code change needed
@@ -108,10 +114,9 @@ Reorganized all `docs/` content into a clear, navigable directory layout. Fixed 
 
 ## Next Steps
 
-1. **ISO-8859-1 encoding support** — all corpus files are Latin-1.
-2. **Regression tests for untested parsers** — 10 of 13 parsers have no dedicated tests.
-3. **Null byte stripping preprocessor** — unblocks Excesos-Mod.
-4. **Backslash context-sensitivity in ~V** — `FIEBDC-3/2020\02102025` uses `\` as date separator.
+1. **Regression tests for untested parsers** — 10 of 13 parsers have no dedicated tests.
+2. **Null byte stripping preprocessor** — unblocks Excesos-Mod.
+3. **Backslash context-sensitivity in ~V** — `FIEBDC-3/2020\02102025` uses `\` as date separator.
 
 ---
 

--- a/docs/ai-workflow/current-handover.md
+++ b/docs/ai-workflow/current-handover.md
@@ -6,6 +6,12 @@
 
 ## Recent Changes
 
+### 2026-05-06 — Fix: verify KParser handles negative digit counts (#98)
+
+- **Added test** for `-9` digit count (VQUISI corpus pattern). KParser stores subfields as strings — no code change needed
+- **Branch:** `fix/98-k-negative-digit-counts`
+- Fixes #98
+
 ### 2026-05-06 — Fix: ~D records emit diagnostics for unmatched codes (#96)
 
 - **Added warn-level diagnostics** in `BC3Builder.assembleHierarchy()` when ~D parent or child code does not match any ~C concept
@@ -96,17 +102,16 @@ Reorganized all `docs/` content into a clear, navigable directory layout. Fixed 
 
 ## Notes
 
-- All 102 tests pass; `npm run ci` passes.
+- All 103 tests pass; `npm run ci` passes.
 - Old root-level doc stubs have been deleted. All broken references across the repo have been fixed.
 - The DParser heuristic for detecting child codes requires 4+ digit numeric codes or alphanumeric codes. Short numeric codes (1-3 digits) without letters are still treated as percentage codes — this is a pre-existing limitation, not introduced by this fix.
 
 ## Next Steps
 
-1. **Fix KParser negative digit counts** — VQUISI has `-9` as first digit count. See work-to-issue-mapping.md Priority 1 #4.
-2. **ISO-8859-1 encoding support** — all corpus files are Latin-1.
-3. **Regression tests for untested parsers** — 10 of 13 parsers have no dedicated tests.
-4. **Null byte stripping preprocessor** — unblocks Excesos-Mod.
-5. **Backslash context-sensitivity in ~V** — `FIEBDC-3/2020\02102025` uses `\` as date separator.
+1. **ISO-8859-1 encoding support** — all corpus files are Latin-1.
+2. **Regression tests for untested parsers** — 10 of 13 parsers have no dedicated tests.
+3. **Null byte stripping preprocessor** — unblocks Excesos-Mod.
+4. **Backslash context-sensitivity in ~V** — `FIEBDC-3/2020\02102025` uses `\` as date separator.
 
 ---
 

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -12,6 +12,14 @@ The API must remain stable over time. Internal modules (importers/parsing/builde
 >
 > `ParseResult` has `{ document: BC3Document; diagnostics: Diagnostic[] }`.
 >
+> **Encoding:** `BC3.parse()` accepts a UTF-16 JavaScript string. All real-world BC3 corpus files use ISO-8859-1 (Latin-1) encoding. Callers must decode before parsing:
+>
+> ```ts
+> // Node.js
+> const input = fs.readFileSync('file.bc3', 'latin1');
+> const result = BC3.parse(input, { mode: 'lenient' });
+> ```
+>
 > Sections below marked **[ASPIRATIONAL]** describe design goals that are **not yet implemented**.
 
 ---

--- a/tests/api/KCoefficients.test.ts
+++ b/tests/api/KCoefficients.test.ts
@@ -13,6 +13,12 @@ const WITHOUT_K_BC3 = [
   '~C|01||Concept|||0|',
 ].join('\r\n');
 
+const NEGATIVE_DIGIT_K_BC3 = [
+  '~V|O|FIEBDC-3/2012||||||',
+  '~K|-9\\0\\0\\0\\0\\0\\0\\0||0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\|',
+  '~C|01||Concept|||0|',
+].join('\r\n');
+
 describe('~K coefficient data in BC3Document', () => {
   it('exposes coefficients when ~K record is present', () => {
     const result = BC3.parse(WITH_K_BC3, { mode: 'lenient' });
@@ -41,5 +47,14 @@ describe('~K coefficient data in BC3Document', () => {
     assert.ok(result.document);
     assert.ok(result.document.coefficients);
     assert.ok(result.document.coefficients.legacy.length > 0);
+  });
+
+  it('handles negative digit count values (VQUISI)', () => {
+    const result = BC3.parse(NEGATIVE_DIGIT_K_BC3, { mode: 'lenient' });
+    assert.ok(result.document);
+    assert.ok(result.document.coefficients);
+
+    assert.equal(result.document.coefficients.legacy[0], '-9');
+    assert.equal(result.document.coefficients.legacy.length, 8);
   });
 });


### PR DESCRIPTION
## Summary
is not neccesary by the moment

## Linked issue
- Closes #100 

## Type of change
- [ ] Feature
- [ ] Bug fix
- [x] Docs
- [ ] Chore / CI
- [ ] Refactor

## Changesets
- [ ] This PR requires a release (public API / behavior change) → `npm run changeset` added
- [x] This PR does NOT require a release (docs/ci/internal tooling only)

> If a Changeset is required, ensure a file exists in `.changeset/`.

## Checklist
- [x] `npm run ci` passes locally
- [x] Code is formatted (Prettier)
- [x] No unnecessary files committed (e.g. `dist/`, `node_modules/`)
- [x] Public API changes are documented (README / docs)
- [x] Backward compatibility considered (if applicable)

## Notes for reviewers
- Anything to pay attention to?
