### PR TITLE
feat: strip null bytes from input before tokenizing

### DIFF
--- a/docs/ai-workflow/current-handover.md
+++ b/docs/ai-workflow/current-handover.md
@@ -6,6 +6,12 @@
 
 ## Recent Changes
 
+### 2026-05-06 — Feature: strip null bytes from input (#104)
+
+- **Added `stripNullBytes()`** in Tokenizer — removes `\x00` (NUL) bytes before tokenizing. Unblocks Excesos-Mod corpus file (37,713 lines with NUL contamination)
+- **Branch:** `feat/104-null-byte-stripping`
+- Fixes #104
+
 ### 2026-05-06 — Test: add regression tests for untested parsers (#102)
 
 - **Added 17 regression tests** covering ~T, ~M, ~E, ~A, ~X, ~L, ~N, ~B, ~Y, and UnknownRecordParser
@@ -116,15 +122,14 @@ Reorganized all `docs/` content into a clear, navigable directory layout. Fixed 
 
 ## Notes
 
-- All 119 tests pass; `npm run ci` passes.
+- All 120 tests pass; `npm run ci` passes.
 - Old root-level doc stubs have been deleted. All broken references across the repo have been fixed.
 - The DParser heuristic for detecting child codes requires 4+ digit numeric codes or alphanumeric codes. Short numeric codes (1-3 digits) without letters are still treated as percentage codes — this is a pre-existing limitation, not introduced by this fix.
 
 ## Next Steps
 
-1. **Null byte stripping preprocessor** — unblocks Excesos-Mod.
-2. **Backslash context-sensitivity in ~V** — `FIEBDC-3/2020\02102025` uses `\` as date separator.
-3. **Implement ~G parser** — image/graphic attachment (1 occurrence).
+1. **Backslash context-sensitivity in ~V** — `FIEBDC-3/2020\02102025` uses `\` as date separator.
+2. **Implement ~G parser** — image/graphic attachment (1 occurrence).
 
 ---
 

--- a/src/parsing/Tokenizer.ts
+++ b/src/parsing/Tokenizer.ts
@@ -25,6 +25,10 @@ function stripEofMarker(input: string): string {
   return eof >= 0 ? input.slice(0, eof) : input;
 }
 
+function stripNullBytes(input: string): string {
+  return input.replace(/\x00/g, '');
+}
+
 function isWsCharCode(code: number): boolean {
   return WHITESPACE_CHAR_CODES.includes(code);
 }
@@ -121,7 +125,7 @@ export class Tokenizer implements TokenizerInterface {
     const trimBoth = options.trimAroundSeparators ?? true;
     const lenient = options.lenient ?? true;
 
-    const src = stripEofMarker(input);
+    const src = stripEofMarker(stripNullBytes(input));
     const recordStarts = findRecordStarts(src, lenient);
 
     const records: RawRecord[] = [];

--- a/tests/parsing/Tokenizer.test.ts
+++ b/tests/parsing/Tokenizer.test.ts
@@ -220,5 +220,12 @@ describe('Tokenizer', () => {
       const records = tokenize('~V|A|\n~C|B|\n');
       assert.equal(records.length, 2);
     });
+
+    it('strips null bytes from input', () => {
+      const records = tokenize('~V|\x00A|\r\n\x00~C|B\x00|\r\n');
+      assert.equal(records.length, 2);
+      assert.equal(records[0]!.type, 'V');
+      assert.equal(records[1]!.type, 'C');
+    });
   });
 });


### PR DESCRIPTION
Adds stripNullBytes() preprocessing step in Tokenizer. Removes \x00 (NUL) bytes before record detection.
Unblocks Excesos-Mod corpus file (37,713 lines with null byte contamination).

Fixes #104