### PR TITLE
fix: reconstruct version field in VParser for backslash context-sensi…

### DIFF
--- a/docs/ai-workflow/current-handover.md
+++ b/docs/ai-workflow/current-handover.md
@@ -13,6 +13,15 @@
 - **GitHub topics** set: `bc3`, `fiebdc`, `fiebdc-3`, `construction`, `parser`, `typescript`, `nodejs`, `boq`, `cost-estimation`.
 - **Commit:** `d2510cf` on `develop`
 
+### 2026-05-06 — Fix: backslash context-sensitivity in ~V (#106)
+
+- **VParser** now reconstructs the version field by joining subfields with `\`, then splits on the **last** `\` to separate version from optional date suffix.
+- Previously relied on tokenizer's accidental subfield splitting (`f[1][0]`=version, `f[1][1]`=date). Now explicit: `raw = f[1].join('\\')`, `lastBackslash ≥ 0` → version/date split.
+- Handles version strings with embedded backslashes (e.g. `FIEBDC-3\2020\02102025` → version=`FIEBDC-3\2020`, date=`02102025`).
+- **Added 2 tests** to `tests/parsing/dispatch/parsers/VCParser.test.ts` (preserves explicit backslash, leading backslash edge case).
+- **Branch:** `fix/106-v-backslash-context`
+- Fixes #106
+
 ### 2026-05-06 — SEO P2: description, badges, "Why" block, Related Terms, repo desc
 
 - **package.json description** expanded with `FIEBDC-3/BC3`, `TypeScript parser`, `Presto`, `ARQUIMEDES`, `TCQ`, `bills of quantities`.

--- a/src/parsing/dispatch/parsers/VParser.ts
+++ b/src/parsing/dispatch/parsers/VParser.ts
@@ -6,22 +6,28 @@ export class VParser implements RecordParser {
   readonly type = 'V';
 
   parse(record: RawRecord, ctx: ParseContext): void {
-    // ~V | PROPIEDAD | VERSION \ FECHA | PROGRAMA | CABECERA \ ROTULOS... | JUEGO | COMENTARIO | TIPO | NUMCERT | FECHACERT | URL_BASE |
     const f = record.fields;
 
     const property = f[0]?.[0] ?? '';
-    const version = f[1]?.[0] ?? '';
-    const versionDate = f[1]?.[1] ?? '';
+
+    const rawVersionField = (f[1] ?? []).join('\\');
+    const lastBackslash = rawVersionField.lastIndexOf('\\');
+    const version =
+      lastBackslash >= 0
+        ? rawVersionField.slice(0, lastBackslash)
+        : rawVersionField;
+    const versionDate =
+      lastBackslash >= 0 ? rawVersionField.slice(lastBackslash + 1) : '';
 
     const program = f[2]?.[0] ?? '';
 
     const header = f[3]?.[0] ?? '';
     const labels = (f[3] ?? []).slice(1).filter(Boolean);
 
-    const charset = f[4]?.[0] ?? ''; // 850/437/ANSI
+    const charset = f[4]?.[0] ?? '';
     const comment = f[5]?.[0] ?? '';
 
-    const infoType = f[6]?.[0] ?? ''; // 1..4
+    const infoType = f[6]?.[0] ?? '';
     const certificateNumber = f[7]?.[0] ?? '';
     const certificateDate = f[8]?.[0] ?? '';
 

--- a/tests/parsing/dispatch/parsers/VCParser.test.ts
+++ b/tests/parsing/dispatch/parsers/VCParser.test.ts
@@ -25,6 +25,13 @@ const V_EMPTY_OPTIONALS = '~V|OBRA|FIEBDC-3/2020|||||||';
 /** Two ~V records in one file — last one should win (or first, depending on implementation) */
 const V_DUPLICATE = '~V|OBRA1|FIEBDC-3/2002|\r\n~V|OBRA2|FIEBDC-3/2020|\r\n';
 
+/** ~V with backslash embedded in version name (not a subfield separator) */
+const V_BACKSLASH_IN_VERSION =
+  '~V|OBRA|FIEBDC-3\\2020\\02102025|TestProgram|Header|||1|||';
+
+/** ~V with version field consisting only of leading backslash + date */
+const V_LEADING_BACKSLASH = '~V|OBRA|\\02102025|TestProgram|Header|||1|||';
+
 // ---------------------------------------------------------------------------
 // ~C (Concept) fixtures
 // ---------------------------------------------------------------------------
@@ -70,6 +77,18 @@ describe('VParser (~V records)', () => {
     it('versionDate is empty string when absent', () => {
       const { document } = BC3.parse(V_MINIMAL);
       assert.equal(document?.metadata?.versionDate, '');
+    });
+
+    it('preserves explicit backslash in version name (last \\ is date separator)', () => {
+      const { document } = BC3.parse(V_BACKSLASH_IN_VERSION);
+      assert.equal(document?.metadata?.version, 'FIEBDC-3\\2020');
+      assert.equal(document?.metadata?.versionDate, '02102025');
+    });
+
+    it('handles version field with only a leading backslash', () => {
+      const { document } = BC3.parse(V_LEADING_BACKSLASH);
+      assert.equal(document?.metadata?.version, '');
+      assert.equal(document?.metadata?.versionDate, '02102025');
     });
   });
 


### PR DESCRIPTION
…tivity

The \ in FIEBDC-3/2020\02102025 is a version/date separator, not a subfield separator. VParser now joins f[1] subfields and splits on the last \ to separate version from optional date suffix. Handles embedded backslashes in the version name.

Fixes #106

## Summary
- What does this PR change?

## Linked issue
- Closes #<issue-number> (or: Fixes / Resolves)

## Type of change
- [ ] Feature
- [x] Bug fix
- [ ] Docs
- [ ] Chore / CI
- [ ] Refactor

## Changesets
- [x] This PR requires a release (public API / behavior change) → `npm run changeset` added
- [ ] This PR does NOT require a release (docs/ci/internal tooling only)

> If a Changeset is required, ensure a file exists in `.changeset/`.

## Checklist
- [x] `npm run ci` passes locally
- [x] Code is formatted (Prettier)
- [x] No unnecessary files committed (e.g. `dist/`, `node_modules/`)
- [x] Public API changes are documented (README / docs)
- [x] Backward compatibility considered (if applicable)

